### PR TITLE
Bug fixes for numpy 2.0 and torch 2.6

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -87,8 +87,8 @@ def normalize(time_series):
     return time_series.mean(), time_series.std()
 
 def read_loader(ABRAfile):
-	alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+128
-	alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+128
+	alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+np.array(128).astype('int8')
+	alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+np.array(128).astype('int8')
 
 	max_index = 2000000000
 	alltrain = alltrain[:max_index].reshape( -1, batchsize, input_size)
@@ -125,7 +125,7 @@ def process_batch(index, inputarr, targetarr, model, args):
 		# Forward pass
 		input_seq = input_seq.long().to(DEVICE)
 		output_seq = model(input_seq).argmax(dim=1).detach().cpu().numpy()
-	return index, np.int8(output_seq-128).flatten(), np.int8(targetarr-128).flatten()
+	return index, np.int8(output_seq-np.array(128).astype('int8')).flatten(), np.int8(targetarr-np.array(128).astype('int8')).flatten()
 
 def main():
 	'''
@@ -166,22 +166,22 @@ def main():
 
 			if ifile >= low and (ifile < high):
 				if args.denoising_model == "punet":
-					model = torch.load(f'PUNet_{low}_{high}.pth',map_location=DEVICE)
+					model = torch.load(f'PUNet_{low}_{high}.pth',map_location=DEVICE, weights_only = False)
 					model.eval()
 				elif args.denoising_model == "transformer":
-					model = torch.load(f'Transformer_{low}_{high}.pth',map_location=DEVICE)
+					model = torch.load(f'Transformer_{low}_{high}.pth',map_location=DEVICE, weights_only = False)
 					model.eval()
 				elif args.denoising_model == "fcnet":
-					model = torch.load(f'FCNet_{low}_{high}.pth',map_location=DEVICE)
+					model = torch.load(f'FCNet_{low}_{high}.pth',map_location=DEVICE, weights_only = False)
 					model.eval()
 				elif args.denoising_model == "wavenet":
 					if NFreqSplit:
-						model = torch.load(f'WaveNet_0_20.pth',map_location=DEVICE)
+						model = torch.load(f'WaveNet_0_20.pth',map_location=DEVICE, weights_only = False)
 					else:
-						model = torch.load(f'WaveNet_{low}_{high}.pth',map_location=DEVICE)
+						model = torch.load(f'WaveNet_{low}_{high}.pth',map_location=DEVICE, weights_only = False)
 					model.eval()
 				elif args.denoising_model == "rnn":
-					model = torch.load(f'RNN_{low}_{high}.pth',map_location=DEVICE)
+					model = torch.load(f'RNN_{low}_{high}.pth',map_location=DEVICE, weights_only = False)
 					model.eval()
 				else:
 					'''

--- a/process_science_data.py
+++ b/process_science_data.py
@@ -47,7 +47,7 @@ output_size = input_size
 ADC_CHANNEL = 256
 
 def read_loader(ABRAfile):
-    alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+128
+    alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+np.array(128).astype('int8')
     #change the max_index to length of science data TS series 
     max_index = 4010000000
     alltrain = alltrain[:max_index].reshape( -1, batchsize, input_size)
@@ -142,10 +142,10 @@ def main(args):
         elif args.denoising_model == "fcnet":
             mname = "FCNet"
 
-        model1 = torch.load(f'{mname}_0_4.pth',map_location=DEVICE)
-        model2 = torch.load(f'{mname}_4_10.pth',map_location=DEVICE)
-        model3 = torch.load(f'{mname}_10_15.pth',map_location=DEVICE)
-        model4 = torch.load(f'{mname}_15_20.pth',map_location=DEVICE)
+        model1 = torch.load(f'{mname}_0_4.pth',map_location=DEVICE, weights_only = False)
+        model2 = torch.load(f'{mname}_4_10.pth',map_location=DEVICE, weights_only = False)
+        model3 = torch.load(f'{mname}_10_15.pth',map_location=DEVICE, weights_only = False)
+        model4 = torch.load(f'{mname}_15_20.pth',map_location=DEVICE, weights_only = False)
 
         model1.eval()
         model2.eval()
@@ -176,10 +176,10 @@ def main(args):
                 output_seq3 = model3(input_seq).argmax(dim=1)
                 output_seq4 = model4(input_seq).argmax(dim=1)
 
-            denoised1.append(np.int8(output_seq1.detach().cpu().numpy().flatten()-128))
-            denoised2.append(np.int8(output_seq2.detach().cpu().numpy().flatten()-128))
-            denoised3.append(np.int8(output_seq3.detach().cpu().numpy().flatten()-128))
-            denoised4.append(np.int8(output_seq4.detach().cpu().numpy().flatten()-128))
+            denoised1.append(np.int8(output_seq1.detach().cpu().numpy().flatten()-np.array(128).astype('int8')))
+            denoised2.append(np.int8(output_seq2.detach().cpu().numpy().flatten()-np.array(128).astype('int8')))
+            denoised3.append(np.int8(output_seq3.detach().cpu().numpy().flatten()-np.array(128).astype('int8')))
+            denoised4.append(np.int8(output_seq4.detach().cpu().numpy().flatten()-np.array(128).astype('int8')))
 
 		# These are 4 version of the denoised time series with parameters trained on different frequency ranges, change the note var to specify in saved file name
         process_denoised(denoised1, note = mname+'_0_4pth_file'+str(ifile))

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ setup(
     name='environment_setup',
     version='0.1',
     install_requires=[
-        'numpy',
+        'numpy >= 2.0',
         'scipy',
         'tqdm',
-        'torch',  # PyTorch is listed as 'torch' in PyPI
+        'torch >= 2.6',  # PyTorch is listed as 'torch' in PyPI
         'h5py',
         'jaxlib',
         'jax',

--- a/train.py
+++ b/train.py
@@ -51,8 +51,8 @@ def normalize(time_series):
     return time_series.mean(), time_series.std()
 
 def read_loader(ABRAfile):
-    alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+128
-    alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+128
+    alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+np.array(128).astype('int8')
+    alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+np.array(128).astype('int8')
 
     max_index = 2000000000
     alltrain = alltrain[:max_index].reshape( -1,sample_size, batchsize, input_size)

--- a/train_nosplit.py
+++ b/train_nosplit.py
@@ -58,8 +58,8 @@ def normalize(time_series):
     return time_series.mean(), time_series.std()
 
 def read_loader(ABRAfile):
-	alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+128
-	alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+128
+	alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+np.array(128).astype('int8')
+	alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+np.array(128).astype('int8')
 
 	max_index = 2000000000
 	alltrain = alltrain[:max_index].reshape( -1,sample_size, batchsize, input_size)
@@ -95,15 +95,15 @@ class TIDMADDataset(Dataset):
         #     input_series = np.array(f['timeseries']['channel0001']['timeseries'])[start:end].reshape(batchsize, input_size)
         #     target_series = np.array(f['timeseries']['channel0002']['timeseries'])[start:end].reshape(batchsize, input_size)
 
-        return input_series.astype(np.int16)+128, target_series.astype(np.int16)+128
+        return input_series.astype(np.int16)+np.array(128).astype('int16'), target_series.astype(np.int16)+np.array(128).astype('int16')
 
     def return_time_channel(self):
         return (self.__getitem__(0)[0].shape[0], self.__getitem__(0)[0].shape[1])
 
     def pull_event_from_dir(self,filelist):
 
-        # alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+128
-        # alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+128
+        # alltrain = np.array(ABRAfile['timeseries']['channel0001']['timeseries'])+np.array(128).astype('int8')
+        # alltarget = np.array(ABRAfile['timeseries']['channel0002']['timeseries'])+np.array(128).astype('int8')
 
         # max_index = 2000000000
         # alltrain = alltrain[:max_index].reshape( -1,sample_size, batchsize, input_size)


### PR DESCRIPTION
Some small bug fixes detailed below:

Updated the method of adding `128` to the timeseries values so that it is compatible with numpy 2.0. Also updated the `torch.load()` calls to be compatible with torch 2.6. Updated setup.py to have version requirements for numpy and torch.